### PR TITLE
Allow updateTranslation(...) to co-exist with other transformation like scale.

### DIFF
--- a/raphael.group.js
+++ b/raphael.group.js
@@ -43,6 +43,9 @@ Raphael.fn.group = function(){
 			if (!transform) {
 				return translateString;
 			}
+			if (transform.indexOf('translate(') < 0) {
+				return transform + ' ' + translateString;
+			}
 			return transform.replace(/translate\(-?[0-9]*?\.?[0-9]*?\ -?[0-9]*?\.?[0-9]*?\)/, translateString);
 		}
 		


### PR DESCRIPTION
Calling updateTranslation when translate transform doesn't exist would swallow other transforms like scale because we did not check for the existent of translate like the other functions, eg. updateScale() and updateRotation()
